### PR TITLE
fix: types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,18 +27,14 @@ type HashAlgo =
   | 'sha-384'
   | 'sha-512'
 
-type Uint8 = Uint8Array | Array
+type Uint8 = Uint8Array | Array<number>
 
-type HexPrimitive = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | 'a' | 'b' | 'c' | 'd' | 'e' | 'f'
-type HexPart<S extends string | number> = `${S}${'' | `${S}`}`
-type Hex = HexPart<HexPart<HexPrimitive>>
+type Hex = string
 
-type BasePrimitive = "A"|"B"|"C"|"D"|"E"|"F"|"G"|"H"|"I"|"J"|"K"|"L"|"M"|"N"|"O"|"P"|"Q"|"R"|"S"|"T"|"U"|"V"|"W"|"X"|"Y"|"Z"|"a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"|"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v"|"w"|"x"|"y"|"z"|"0"|"1"|"2"|"3"|"4"|"5"|"6"|"7"|"8"|"9"|"+"|"/"|"="
-type BasePart<S extends string> = `${S}${'' | `${S}`}`
-type Base64 = BasePart<BasePart<BasePrimitive>>
+type Base64 = string
 
 
-export function concat (chunks: (TypedArray | Array)[], size?: number): Uint8Array
+export function concat (chunks: (TypedArray | Array<number>)[], size?: number): Uint8Array
 
 export function equal (a: Uint8, b: Uint8): boolean
 
@@ -58,6 +54,6 @@ export function hex2bin (str: Hex): string
 
 export function bin2hex (str: string): Hex
 
-export async function hash (data: string | TypedArray | ArrayBuffer | DataView, format?: HashType, algo?: HashAlgo): Promise<Uint8Array | Hex | Base64>
+export function hash (data: string | TypedArray | ArrayBuffer | DataView, format?: HashType, algo?: HashAlgo): Promise<Uint8Array | Hex | Base64>
 
 export function randomBytes (size: number): Uint8Array


### PR DESCRIPTION
Fix four TypeScript errors when this package is imported in another project using TypeScript 5.1.6.

The errors were:
```
node_modules/.pnpm/uint8-util@2.2.2/node_modules/uint8-util/index.d.ts:30:27 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

30 type Uint8 = Uint8Array | Array
                             ~~~~~

node_modules/.pnpm/uint8-util@2.2.2/node_modules/uint8-util/index.d.ts:38:15 - error TS2590: Expression produces a union type that is too complex to represent.

38 type Base64 = BasePart<BasePart<BasePrimitive>>
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/.pnpm/uint8-util@2.2.2/node_modules/uint8-util/index.d.ts:41:47 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

41 export function concat (chunks: (TypedArray | Array)[], size?: number): Uint8Array
                                                 ~~~~~

node_modules/.pnpm/uint8-util@2.2.2/node_modules/uint8-util/index.d.ts:61:8 - error TS1040: 'async' modifier cannot be used in an ambient context.

61 export async function hash (data: string | TypedArray | ArrayBuffer | DataView, format?: HashType, algo?: HashAlgo): Promise<Uint8Array | Hex | Base64>
          ~~~~~
```

Unfortunately I had to *weaken* the types for `Base64`, as the desired effect causes compilation error.

I also changed `Hex` type to `string`, because the `Hex` as written can only accept hexadecimal strings up to four characters long, and anything longer is not accepted.