### PR TITLE
Type Narrowing on `hash`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ export function hex2bin (str: Hex): string
 
 export function bin2hex (str: string): Hex
 
+export function hash (data: string | TypedArray | ArrayBuffer | DataView, format?: undefined, algo?: HashAlgo): Promise<Uint8Array>
+export function hash (data: string | TypedArray | ArrayBuffer | DataView, format: HashType, algo?: HashAlgo): Promise<Hex | Base64>
 export function hash (data: string | TypedArray | ArrayBuffer | DataView, format?: HashType, algo?: HashAlgo): Promise<Uint8Array | Hex | Base64>
 
 export function randomBytes (size: number): Uint8Array


### PR DESCRIPTION
This function is used throughout the WebTorrent codebase. Impact should be minimal (though technically breaking) and this change will avoid a bunch of different lines of code, once converted to TypeScript, where it would have to be casted like in this snippet (based on `bittorrent-tracker`): 

```typescript
const hash1Buffer = await hash(hex2arr(this._utfToHex('req1') + this._sharedSecret)) as Uint8Array
const hash2Buffer = await hash(hex2arr(this._utfToHex('req2') + infoHash)) as Uint8Array
const hash3Buffer = await hash(hex2arr(this._utfToHex('req3') + this._sharedSecret)) as Uint8Array
```

It's not a big deal, of course, but I think that during code review looking at a cast like this may be needlessly alarming.